### PR TITLE
Removing null character \u0000 from body

### DIFF
--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -34,7 +34,7 @@ module MetaInspector
       return unless response
       body = response.body
       body = body.encode!(@encoding, @encoding, :invalid => :replace) if @encoding
-      body.tr("\000", '')
+      body = body.tr("\000", '').tr('\u0000', '')
     rescue ArgumentError => e
       raise MetaInspector::RequestError.new(e)
     end


### PR DESCRIPTION
Removing \u0000 from body to prevent from errors related to ilegal characters.